### PR TITLE
Switch into FQ - bbr2 doesn't work with FQ_CODEL properly

### DIFF
--- a/sys-kernel/cachyos-sources/cachyos-sources-6.3.4.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.3.4.ebuild
@@ -126,6 +126,13 @@ scripts/config -e TCP_CONG_BBR2
 scripts/config -e DEFAULT_BBR2
 scripts/config --set-str DEFAULT_TCP_CONG bbr2
 
+# Switch into FQ - bbr2 doesn't work properly with FQ_CODEL
+scripts/config -m NET_SCH_FQ_CODEL
+scripts/config -e NET_SCH_FQ
+scripts/config -d DEFAULT_FQ_CODEL
+scripts/config -e DEFAULT_FQ
+scripts/config --set-str DEFAULT_NET_SCH fq
+
 # Disable DEBUG
 scripts/config -d DEBUG_INFO
 scripts/config -d DEBUG_INFO_BTF


### PR DESCRIPTION
When you use FQ_CODEL, you may experience problems with downloading large amounts of data - for example, on Steam. Changing to FQ should solve this problem

