### PR TITLE
Ananicy-cpp uses incorrect path for sysctl on Gentoo

### DIFF
--- a/app-admin/ananicy-cpp/files/ananicy-cpp.initd
+++ b/app-admin/ananicy-cpp/files/ananicy-cpp.initd
@@ -6,11 +6,11 @@ command_args="start"
 command_background=true
 
 start_pre() {
-	/usr/sbin/sysctl -e kernel.sched_autogroup_enabled=0
+	/sbin/sysctl -e kernel.sched_autogroup_enabled=0
 }
 
 stop_post() {
-	/usr/sbin/sysctl -e kernel.sched_autogroup_enabled=1
+	/sbin/sysctl -e kernel.sched_autogroup_enabled=1
 }
 
 stop() {


### PR DESCRIPTION
Hello! Thanks for the new repo for CachyOS on Gentoo - I'm very glad to be able to continue using it.

I noticed that after I installed ananicy-cpp, if you try starting it, the service crashes and complains about an incorrect path for sysctl. After manually adjusting the path in ananicy-cpp.initd, from `/usr/sbin/sysctl` to `/sbin/sysctl`, it seems to start up and function fine. I'm using OpenRC, if it matters.