### PR TITLE
Check both /sbin paths for sysctl

### DIFF
--- a/app-admin/ananicy-cpp/files/ananicy-cpp.initd
+++ b/app-admin/ananicy-cpp/files/ananicy-cpp.initd
@@ -6,7 +6,7 @@ command_args="start"
 command_background=true
 
 start_pre() {
-	/sbin/sysctl -e kernel.sched_autogroup_enabled=0
+	/usr/sbin/sysctl -e kernel.sched_autogroup_enabled=0
 	if [ $? -ne 0 ]
 	then
 		/sbin/sysctl -e kernel.sched_autogroup_enabled=0
@@ -14,7 +14,7 @@ start_pre() {
 }
 
 stop_post() {
-	/sbin/sysctl -e kernel.sched_autogroup_enabled=1
+	/usr/sbin/sysctl -e kernel.sched_autogroup_enabled=1
 	if [ $? -ne 0 ]
 	then
 		/sbin/sysctl -e kernel.sched_autogroup_enabled=1

--- a/app-admin/ananicy-cpp/files/ananicy-cpp.initd
+++ b/app-admin/ananicy-cpp/files/ananicy-cpp.initd
@@ -7,10 +7,18 @@ command_background=true
 
 start_pre() {
 	/sbin/sysctl -e kernel.sched_autogroup_enabled=0
+	if [ $? -ne 0 ]
+	then
+		/sbin/sysctl -e kernel.sched_autogroup_enabled=0
+	fi
 }
 
 stop_post() {
 	/sbin/sysctl -e kernel.sched_autogroup_enabled=1
+	if [ $? -ne 0 ]
+	then
+		/sbin/sysctl -e kernel.sched_autogroup_enabled=1
+	fi
 }
 
 stop() {


### PR DESCRIPTION
After realizing I needed to downgrade procps to version 3, I also realized that indeed the original path was correct for base gentoo, which installs sysctl to /usr/sbin instead of /sbin. pg_overlay's version uses /sbin, whether due to avoiding conflict or because they prefer that location. I wrote an updated patch that tries the path for Gentoo's official procps version, and if it fails, tries to run sysctl from /sbin instead. This should support users of both repos, and allow one to switch back and forth without any issues. 

I'm very sorry about not catching this earlier, it didn't occur to me that the overlay uses a different location that the original, and that's what was causing the path error.