### PR TITLE
Fixed cachyos-sources not unpacking when zfs use flag was not enabled

### DIFF
--- a/sys-kernel/cachyos-sources/cachyos-sources-6.11.6.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.11.6.ebuild
@@ -67,8 +67,8 @@ _set_hztick_rate() {
 src_unpack() {
 	kernel-2_src_unpack
 	### Push ZFS to linux
-	use zfs && unpack zfs-$ZFS_COMMIT.tar.gz && mv zfs-$ZFS_COMMIT zfs || die
-	use zfs && cp $FILESDIR/kernel-build-zsh.sh zfs/ || die
+	use zfs && (unpack zfs-$ZFS_COMMIT.tar.gz && mv zfs-$ZFS_COMMIT zfs || die)
+	use zfs && (cp $FILESDIR/kernel-build-zsh.sh zfs/ || die)
 }
 
 src_prepare() {


### PR DESCRIPTION
When the zfs use flag was not enabled the ebuild would error and fail to unpack. This change causes the intended behavior. This would fix https://github.com/Szowisz/CachyOS-kernels/issues/18#issue-2629563973