### PR TITLE
sys-kernel/cachy-sources: fix eevdf and rt-bore scheduler patches

### DIFF
--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.0.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.0.1.ebuild
@@ -86,7 +86,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.0.2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.0.2.ebuild
@@ -86,7 +86,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.0.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.0.ebuild
@@ -86,7 +86,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.1.ebuild
@@ -86,7 +86,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.10.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.10.ebuild
@@ -89,7 +89,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.12.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.12.ebuild
@@ -89,12 +89,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.13.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.13.ebuild
@@ -89,12 +89,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.14.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.14.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.16.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.16.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.17.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.17.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.18.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.18.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.19.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.19.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.2.ebuild
@@ -86,7 +86,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.20.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.20.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.22.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.22.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.23.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.23.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.24.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.24.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.25.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.25.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.26.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.26.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.28.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.28.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.29.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.29.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.3.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.3.ebuild
@@ -86,7 +86,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.30.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.30.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.32.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.32.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.33.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.33.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.34.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.34.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.35.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.35.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.36.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.36.ebuild
@@ -88,12 +88,17 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		eapply "${files_dir}/sched/0001-bore-cachy-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.4.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.4.ebuild
@@ -86,7 +86,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.40.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.40.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.42.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.42.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.43-r1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.43-r1.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.43.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.43.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.44.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.44.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.45.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.45.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.47.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.47.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.48.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.48.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.49.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.49.ebuild
@@ -86,11 +86,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.5.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.5.ebuild
@@ -87,7 +87,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.50.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.50.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.6.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.6.ebuild
@@ -87,7 +87,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.7.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.7.ebuild
@@ -89,7 +89,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.8.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.8.ebuild
@@ -89,7 +89,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.12.9.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.12.9.ebuild
@@ -88,7 +88,6 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.0.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.0.ebuild
@@ -90,11 +90,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.1.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.2.ebuild
@@ -90,11 +90,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.3.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.3.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.4.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.4.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.5.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.5.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.6.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.6.1.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.6.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.6.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.13.7.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.13.7.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.0-r2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.0-r2.ebuild
@@ -91,11 +91,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.0-r4.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.0-r4.ebuild
@@ -91,11 +91,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.0.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.0.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.1.ebuild
@@ -91,11 +91,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.2.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.3.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.3.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.4.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.4.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.5-r2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.5-r2.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.5.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.5.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.6.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.6.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.7-r2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.7-r2.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.7.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.7.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.14.8.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.14.8.ebuild
@@ -92,11 +92,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.0.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.0.ebuild
@@ -90,11 +90,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.1-r1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.1-r1.ebuild
@@ -90,11 +90,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.1.ebuild
@@ -90,11 +90,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.2.ebuild
@@ -90,11 +90,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.3.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.3.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.4-r2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.4-r2.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.4.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.4.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.5.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.5.ebuild
@@ -89,11 +89,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.6.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.6.ebuild
@@ -143,11 +143,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.7.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.7.ebuild
@@ -143,11 +143,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.15.8.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.15.8.ebuild
@@ -143,11 +143,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.0.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.0.ebuild
@@ -144,11 +144,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.1.ebuild
@@ -144,11 +144,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.2.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.2.ebuild
@@ -144,11 +144,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.3.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.3.ebuild
@@ -144,11 +144,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.4-r1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.4-r1.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.4.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.4.ebuild
@@ -144,11 +144,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.5.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.5.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.6.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.6.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.7.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.7.ebuild
@@ -128,18 +128,18 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 
-	if use hardened; then
-		eapply "${files_dir}/misc/0001-hardened.patch"
-		cp "${files_dir}/config-hardened" .config || die
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
 	fi
 
 	if use deckify; then

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.8.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.8.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.16.9.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.16.9.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.17.0-r3.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.17.0-r3.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.17.0.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.17.0.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.17.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.17.1.ebuild
@@ -128,11 +128,16 @@ src_prepare() {
 	fi
 
 	if use eevdf; then
-		eapply "${files_dir}/sched/0001-eevdf-next.patch"
 		cp "${files_dir}/config-eevdf" .config || die
 	fi
 
-	if use rt || use rt-bore; then
+	if use rt; then
+		eapply "${files_dir}/misc/0001-rt-i915.patch"
+		cp "${files_dir}/config-rt-bore" .config || die
+	fi
+
+	if use rt-bore; then
+		eapply "${files_dir}/sched/0001-bore-cachy.patch"
 		eapply "${files_dir}/misc/0001-rt-i915.patch"
 		cp "${files_dir}/config-rt-bore" .config || die
 	fi


### PR DESCRIPTION
`>=sys-kernel/cachy-sources-6.12.0` does not correctly handle `USE=eevdf`
upstream has 0001-eevdf-next.patch removed due to it being a backport of 6.12 EEVDF for <= 6.12 kernels, however ebuild still attempts to apply it which causes merge failure.

`>=sys-kernel/cachyos-sources-6.12.12` applies 1 less patches than upstream for bore-rt config which might cause incomplete features. compliation under such setup is not tested.

Fixes #29.