### PR TITLE
virtual: added dist-kernel-7.0.2.ebuild

### DIFF
--- a/virtual/dist-kernel/dist-kernel-7.0.2.ebuild
+++ b/virtual/dist-kernel/dist-kernel-7.0.2.ebuild
@@ -1,0 +1,18 @@
+# Copyright 2021-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Virtual to depend on any Distribution Kernel"
+SLOT="0/${PVR}"
+KEYWORDS="~amd64"
+
+RDEPEND="
+	|| (
+		~sys-kernel/cachyos-kernel-${PV}
+		~sys-kernel/cachyos-kernel-bin-${PV}
+		~sys-kernel/gentoo-kernel-${PV}
+		~sys-kernel/gentoo-kernel-bin-${PV}
+		~sys-kernel/vanilla-kernel-${PV%_p*}
+	)
+"


### PR DESCRIPTION
Noticed that the 7.0.2 kernel will not build due to the dist-kernel ebuild missing, this fixes that.