### PR TITLE
sys-kernel/cachyos-kernel: Don't write localversion file

### DIFF
--- a/sys-kernel/cachyos-kernel/cachyos-kernel-6.18.31.ebuild
+++ b/sys-kernel/cachyos-kernel/cachyos-kernel-6.18.31.ebuild
@@ -223,9 +223,6 @@ src_prepare() {
 	# Apply user patches (from /etc/portage/patches/)
 	eapply_user
 
-	# Set kernel version suffix
-	echo "-cachyos" > localversion.20-pkgname || die
-
 	# --- Kernel config modifications ---
 
 	### Selecting CachyOS config

--- a/sys-kernel/cachyos-kernel/cachyos-kernel-7.0.8.ebuild
+++ b/sys-kernel/cachyos-kernel/cachyos-kernel-7.0.8.ebuild
@@ -219,9 +219,6 @@ src_prepare() {
 	# Apply user patches (from /etc/portage/patches/)
 	eapply_user
 
-	# Set kernel version suffix
-	echo "-cachyos" > localversion.20-pkgname || die
-
 	# --- Kernel config modifications ---
 
 	### Selecting CachyOS config


### PR DESCRIPTION
When updating `cachyos-kernel` the `/usr/src/linux` symlink wasn't getting updated automatically, which breaks automatic rebuilds of external modules (nvidia-drivers, zfs, etc.).

I think `kernel-build.eclass` doesn't actually parse `localversion.*` files when setting `KV_LOCALVERSION`.  Just using `CONFIG_LOCALVERSION` without any `localversion.*` files works around this.

This also makes the version say `x.x.x-cachyos-dist` instead of `x.x.x-cachyos-cachyos-dist`, which was bothering me a bit.

I have not checked `cachyos-kernel-bin` as they fail to build for me.